### PR TITLE
Fixes #7: Update API/yarn/loader versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@ org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 	# check these on https://fabricmc.net/use
 	minecraft_version=1.16.3
-	yarn_mappings=1.16.3+build.11
-	loader_version=0.9.3+build.207
+	yarn_mappings=1.16.3+build.47
+	loader_version=0.10.6+build.214
 
 # Mod Properties
-	mod_version = 1.0.7
+	mod_version = 1.0.8
 	maven_group = wraith.waystones
 	archives_base_name = wraith-waystones
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.21.0+build.407-1.16
+	fabric_version=0.24.3+build.414-1.16


### PR DESCRIPTION
Please note that this means that anyone making use of this mod will need to be using Fabric API `0.24.3+build.414-1.16` or later.