### PR TITLE
Restore parts lost while adding teleport-utils support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	}
 	modImplementation "com.terraformersmc:modmenu:2.0.14"
 
-	modCompileOnly("curse.maven:teleport-utils-0.2.5-535872:3492182") {
+	modCompileOnly("curse.maven:teleport-utils-0.2.6-535872:3493142") {
 		because "teleporting mechanics can be improved with this library"
 		modCompileOnly("curse.maven:player-vehicle-desync-fix-0.2.2-535864:3490516") {
 			because "this can fix the wrong behavior on teleporting with vehicles"

--- a/src/main/java/wraith/waystones/Waystones.java
+++ b/src/main/java/wraith/waystones/Waystones.java
@@ -146,10 +146,12 @@ public class Waystones implements ModInitializer {
                 (server, player, networkHandler, data, sender) -> {
                     NbtCompound tag = data.readNbt();
                     if (tag == null || !tag.contains("waystone_hash")) {
+                        LOGGER.warn("Tag is null or does not contains waystone_hash, aborting");
                         return;
                     }
                     server.execute(() -> {
                         if (!tag.contains("waystone_hash")) {
+                            LOGGER.warn("Tag does not contains waystone_hash, aborting");
                             return;
                         }
                         String hash = tag.getString("waystone_hash");
@@ -157,10 +159,16 @@ public class Waystones implements ModInitializer {
                                 && tag.getBoolean("from_abyss_watcher");
                         WaystoneBlockEntity waystone = WAYSTONE_STORAGE.getWaystone(hash);
                         if (waystone == null) {
+                            LOGGER.warn("Cannot find waystone for hash {}, forgetting this waystone", hash);
+                            WAYSTONE_STORAGE.removeWaystone(hash);
                             return;
                         }
                         if (waystone.getWorld() != null && !(waystone.getWorld().getBlockState(waystone.getPos())
                                 .getBlock() instanceof WaystoneBlock)) {
+                            LOGGER.warn(
+                                    "Waystone {} (owned by {}) is not there ({}, {}, {}) anymore, forgetting this waystone",
+                                    waystone.getWaystoneName(), waystone.getOwnerName(), waystone.getPos().getX(),
+                                    waystone.getPos().getY(), waystone.getPos().getZ());
                             WAYSTONE_STORAGE.removeWaystone(hash);
                             waystone.getWorld().removeBlockEntity(waystone.getPos());
                         } else if (Utils.canTeleport(player, hash)) {
@@ -179,6 +187,9 @@ public class Waystones implements ModInitializer {
                                 player.world.playSound(player, waystonePos, SoundEvents.ENTITY_ENDERMAN_TELEPORT,
                                         SoundCategory.BLOCKS, 1F, 1F);
                             }
+                        } else {
+                            LOGGER.info("Player {} cannot teleport due to umnet requirement",
+                                    player.getName().getString());
                         }
                     });
                 });

--- a/src/main/java/wraith/waystones/block/WaystoneBlockEntity.java
+++ b/src/main/java/wraith/waystones/block/WaystoneBlockEntity.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
 import wraith.waystones.util.TeleporterManager;
 import wraith.waystones.util.Utils;
 import wraith.waystones.interfaces.WaystoneValue;
+import wraith.waystones.mixin.ServerPlayerEntityAccessor;
 import wraith.waystones.Waystones;
 import wraith.waystones.registries.BlockEntityRegistry;
 import wraith.waystones.registries.ItemRegistry;
@@ -354,7 +355,11 @@ public class WaystoneBlockEntity extends LootableContainerBlockEntity
             return;
         }
         playerEntity.getServer().execute(() -> {
+            playerEntity.getEntityWorld().sendEntityStatus(playerEntity, (byte) 46);
+            ServerPlayerEntityAccessor playerAccessor = (ServerPlayerEntityAccessor) playerEntity;
+            playerAccessor.setInTeleportationState(true);
             TeleporterManager.getTeleporter().teleport(playerEntity, (ServerWorld) world, target);
+            playerEntity.onTeleportationDone();
             playerEntity.addExperience(0);
             if (isAbyssWatcher
                     && playerEntity.getMainHandStack().getItem() == ItemRegistry.ITEMS.get("abyss_watcher")) {
@@ -371,6 +376,7 @@ public class WaystoneBlockEntity extends LootableContainerBlockEntity
                 playerEntity.addStatusEffect(effect);
             }
             playerEntity.setAbsorptionAmount(absorption);
+            playerEntity.getEntityWorld().sendEntityStatus(playerEntity, (byte) 46);
         });
 
     }

--- a/src/main/java/wraith/waystones/mixin/ServerPlayerEntityAccessor.java
+++ b/src/main/java/wraith/waystones/mixin/ServerPlayerEntityAccessor.java
@@ -11,4 +11,7 @@ public interface ServerPlayerEntityAccessor {
     @Accessor("networkHandler")
     ServerPlayNetworkHandler getNetworkHandler();
 
+    @Accessor("inTeleportationState")
+    public void setInTeleportationState(boolean inTeleportationState);
+
 }

--- a/src/main/java/wraith/waystones/util/TeleportUtilsTeleporter.java
+++ b/src/main/java/wraith/waystones/util/TeleportUtilsTeleporter.java
@@ -11,7 +11,9 @@ public class TeleportUtilsTeleporter implements ServerPlayerEntityTeleporter {
 
     @Override
     public void teleport(ServerPlayerEntity player, ServerWorld targetWorld, TeleportTarget target) {
-        TeleportUtils.teleportEntityWithItsPassengersLeashedAnimalsAndVehiclesRecursively(player, target, targetWorld);
+        // let waystones do the particle and sound things
+        TeleportUtils.teleportEntityWithItsPassengersLeashedAnimalsAndVehiclesRecursively(player, target, targetWorld,
+                false, false);
     }
 
 }


### PR DESCRIPTION
Main Changes:
- restored parts lost while adding teleport-utils support (#59) as much as I could
    - adding particle effect at start and end (`player.getEntityWorld().sendEntityStatus(player, (byte) 46)`)
    - calling `player.onTeleportationDone()` after the teleportation
- set player's teleportation state to `true` before teleporting so that calling `player.onTeleportationDone()` after the teleportation can be meaningful
    - in fact, we can skip the `player.onTeleportationDone()` call after the teleport since it would be called inside `ServerPlayNetworkHandler.onTeleportConfirm()` if the player is in teleportation state

Changes other than that:
- added more logging to `Waystones.java`
- call `WAYSTONE_STORAGE.removeWaystone(hash)` if we cannot find waystone for the given hash
    - Is this ok? I changed this because I accidently ran into this situation that a waystone keeps showing in the list but is not working anymore because of this. I have no idea how this could happen btw (having hash while cannot find the waystone from storage)