### PR TITLE
Fix generateInVillages setting

### DIFF
--- a/src/main/java/wraith/waystones/util/WaystonesWorldgen.java
+++ b/src/main/java/wraith/waystones/util/WaystonesWorldgen.java
@@ -32,8 +32,10 @@ public final class WaystonesWorldgen {
     }
 
     public static void registerVillage(MinecraftServer server, Identifier village, Identifier waystone) {
-        Waystones.LOGGER.info("Adding waystone " + waystone.toString() + " to village " + village.toString());
-        Utils.addToStructurePool(server, village, waystone, 5);
+        if (Config.getInstance().generateInVillages()) {
+            Waystones.LOGGER.info("Adding waystone " + waystone.toString() + " to village " + village.toString());
+            Utils.addToStructurePool(server, village, waystone, 5);
+        }
     }
 
     public static void registerVanillaVillageWorldgen(MinecraftServer server) {


### PR DESCRIPTION
Waystones would still generate if `generateInVillages` is set to `false`, which was a simple 1 line fix.

~~I also noticed you had the some duplicate code between `onInitializeServer()` and `onInitializeClient()` which should just be in the common mod initializer `onInitialize()`.~~