### PR TITLE
fixes #76 by adding 'type' to 'set_contents' function for 1.18

### DIFF
--- a/src/main/resources/data/waystones/loot_tables/blocks/blackstone_waystone.json
+++ b/src/main/resources/data/waystones/loot_tables/blocks/blackstone_waystone.json
@@ -43,6 +43,7 @@
             },
             {
               "function": "minecraft:set_contents",
+              "type": "waystones:waystone",
               "entries": [
                 {
                   "type": "minecraft:dynamic",

--- a/src/main/resources/data/waystones/loot_tables/blocks/deepslate_waystone.json
+++ b/src/main/resources/data/waystones/loot_tables/blocks/deepslate_waystone.json
@@ -43,6 +43,7 @@
             },
             {
               "function": "minecraft:set_contents",
+              "type": "waystones:waystone",
               "entries": [
                 {
                   "type": "minecraft:dynamic",

--- a/src/main/resources/data/waystones/loot_tables/blocks/desert_waystone.json
+++ b/src/main/resources/data/waystones/loot_tables/blocks/desert_waystone.json
@@ -43,6 +43,7 @@
             },
             {
               "function": "minecraft:set_contents",
+              "type": "waystones:waystone",
               "entries": [
                 {
                   "type": "minecraft:dynamic",

--- a/src/main/resources/data/waystones/loot_tables/blocks/nether_waystone.json
+++ b/src/main/resources/data/waystones/loot_tables/blocks/nether_waystone.json
@@ -43,6 +43,7 @@
             },
             {
               "function": "minecraft:set_contents",
+              "type": "waystones:waystone",
               "entries": [
                 {
                   "type": "minecraft:dynamic",

--- a/src/main/resources/data/waystones/loot_tables/blocks/red_desert_waystone.json
+++ b/src/main/resources/data/waystones/loot_tables/blocks/red_desert_waystone.json
@@ -43,6 +43,7 @@
             },
             {
               "function": "minecraft:set_contents",
+              "type": "waystones:waystone",
               "entries": [
                 {
                   "type": "minecraft:dynamic",

--- a/src/main/resources/data/waystones/loot_tables/blocks/red_nether_waystone.json
+++ b/src/main/resources/data/waystones/loot_tables/blocks/red_nether_waystone.json
@@ -43,6 +43,7 @@
             },
             {
               "function": "minecraft:set_contents",
+              "type": "waystones:waystone",
               "entries": [
                 {
                   "type": "minecraft:dynamic",

--- a/src/main/resources/data/waystones/loot_tables/blocks/stone_brick_waystone.json
+++ b/src/main/resources/data/waystones/loot_tables/blocks/stone_brick_waystone.json
@@ -43,6 +43,7 @@
             },
             {
               "function": "minecraft:set_contents",
+              "type": "waystones:waystone",
               "entries": [
                 {
                   "type": "minecraft:dynamic",

--- a/src/main/resources/data/waystones/loot_tables/blocks/waystone.json
+++ b/src/main/resources/data/waystones/loot_tables/blocks/waystone.json
@@ -43,6 +43,7 @@
             },
             {
               "function": "minecraft:set_contents",
+              "type": "waystones:waystone",
               "entries": [
                 {
                   "type": "minecraft:dynamic",


### PR DESCRIPTION
### Scope

This fixes #76 where 1.18 couldn't parse the loot tables anymore. According to the Minecraft wiki [Item modifier](https://minecraft.fandom.com/wiki/Item_modifier) page, the `set_contents` function now requires `type` attribute to set the `BlockEntityTag.id`.

I looked at how Minecraft was handling the shulker box (first instance I found of it using `set_contents`) and it seems the variations and base loot table were using the base shulker box. I set the type here to the base waystone as well across the variants.

### Testing Performed

I was able to craft waystones, place them, and break them with a diamond pickaxe (with and without silk touch), have the appropriate variant dropped as loot and then be able to pick up and place them again. I also traveled between waystones, but did not do any other testing from there.