### PR TITLE
fix dimensional teleport desync

### DIFF
--- a/src/main/java/wraith/waystones/block/WaystoneBlockEntity.java
+++ b/src/main/java/wraith/waystones/block/WaystoneBlockEntity.java
@@ -1,10 +1,10 @@
 package wraith.waystones.block;
 
+import net.fabricmc.fabric.api.dimension.v1.FabricDimensions;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.LootableContainerBlockEntity;
 import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventories;
@@ -22,10 +22,8 @@ import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.collection.DefaultedList;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.*;
+import net.minecraft.world.TeleportTarget;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import wraith.waystones.Waystones;
@@ -37,7 +35,6 @@ import wraith.waystones.util.Utils;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
@@ -335,33 +332,38 @@ public class WaystoneBlockEntity extends LootableContainerBlockEntity implements
         final float fX = x;
         final float fZ = z;
         final float fYaw = yaw;
-        final List<StatusEffectInstance> effects = new ArrayList<>(playerEntity.getStatusEffects());
         if (playerEntity.getServer() == null) {
             return;
         }
-
-        playerEntity.getServer().execute(() -> {
-            player.getEntityWorld().sendEntityStatus(player, (byte) 46);
-            playerEntity.teleport((ServerWorld) world, pos.getX() + fX, pos.getY(), pos.getZ() + fZ, fYaw, 0);
-            playerEntity.onTeleportationDone();
-            playerEntity.addExperience(0);
-            if (isAbyssWatcher && playerEntity.getMainHandStack().getItem() instanceof AbyssWatcherItem) {
-                if (!playerEntity.isCreative()) {
-                    player.sendEquipmentBreakStatus(EquipmentSlot.MAINHAND);
-                    player.sendEquipmentBreakStatus(EquipmentSlot.MAINHAND);
-                    playerEntity.getMainHandStack().decrement(1);
-                    player.world.playSound(null, pos, SoundEvents.BLOCK_GLASS_BREAK, SoundCategory.PLAYERS, 1F, 1F);
-                }
+        TeleportTarget target = new TeleportTarget(
+            new Vec3d(pos.getX() + fX, pos.getY(), pos.getZ() + fZ),
+            new Vec3d(0 ,0, 0),
+            fYaw,
+            0
+        );
+        doTeleport(playerEntity, (ServerWorld) world, target);
+        if (isAbyssWatcher && playerEntity.getMainHandStack().getItem() instanceof AbyssWatcherItem) {
+            if (!playerEntity.isCreative()) {
+                player.sendEquipmentBreakStatus(EquipmentSlot.MAINHAND);
+                player.sendEquipmentBreakStatus(EquipmentSlot.MAINHAND);
+                playerEntity.getMainHandStack().decrement(1);
+                player.world.playSound(null, pos, SoundEvents.BLOCK_GLASS_BREAK, SoundCategory.PLAYERS, 1F, 1F);
             }
+        }
+    }
 
-            float absorption = playerEntity.getAbsorptionAmount();
-            for (StatusEffectInstance effect : effects) {
-                playerEntity.addStatusEffect(effect);
-            }
-            playerEntity.setAbsorptionAmount(absorption);
-            player.getEntityWorld().sendEntityStatus(player, (byte) 46);
-        });
-
+    private void doTeleport(ServerPlayerEntity player, ServerWorld world, TeleportTarget target) {
+        if (player.world.getRegistryKey().equals(world.getRegistryKey())) {
+            player.networkHandler.requestTeleport(
+                target.position.getX(),
+                target.position.getY(),
+                target.position.getZ(),
+                target.yaw,
+                target.pitch
+            );
+        } else {
+            FabricDimensions.teleport(player, world, target);
+        }
     }
 
     public void setName(String name) {


### PR DESCRIPTION
When teleporting across dimensions I've noticed client desync, usually manifesting in the loss of creative flight attained through mods like Winged and Rings of Ascension, though would also cause inability to interact with waystones until relog, nether/end portal use, or swapping gamemode. This was due to the use of  `.execute()` and is a well-known bug with Minecraft itself (https://bugs.mojang.com/browse/MC-124177).

The use of FabricAPI circumvents this bug (kudos to Dimensional Doors developers, we've never had this bug with their teleporting, so I checked out their code for a potential solution and found one 🙏). I've tested in 1.18.1 using Trinkets + Rings of Ascension and was unable to cause desync with dimensional teleport (I maintained my flight, and ability to interact with waystones).

As a bonus, using this method reduces the amount of manual work required when teleporting a player; No need to re-apply status effects nor update the client as FabricAPI handles these things.

My only ask is that this gets an official backport to 1.17.1 as I went through this effort in order to fix this for players of my custom modpack. I'll be backporting it unofficially and building my own jar, but an official backport would be much appreciated 💜