### PR TITLE
proof of concept of limiting waystone to only 1 max per village

### DIFF
--- a/src/main/java/wraith/waystones/mixin/SinglePoolElementAccessor.java
+++ b/src/main/java/wraith/waystones/mixin/SinglePoolElementAccessor.java
@@ -9,8 +9,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(SinglePoolElement.class)
 public interface SinglePoolElementAccessor {
-
     @Accessor("location")
     Either<Identifier, Structure> getLocation();
-
 }

--- a/src/main/java/wraith/waystones/mixin/StructurePoolBasedGeneratorMixin.java
+++ b/src/main/java/wraith/waystones/mixin/StructurePoolBasedGeneratorMixin.java
@@ -1,44 +1,86 @@
-//package wraith.waystones.mixin;
-//
-//import net.minecraft.structure.PoolStructurePiece;
-//import net.minecraft.structure.pool.StructurePool;
-//import net.minecraft.structure.pool.StructurePoolBasedGenerator;
-//import net.minecraft.structure.pool.StructurePoolElement;
-//import org.spongepowered.asm.mixin.Final;
-//import org.spongepowered.asm.mixin.Mixin;
-//import org.spongepowered.asm.mixin.Shadow;
-//import org.spongepowered.asm.mixin.injection.At;
-//import org.spongepowered.asm.mixin.injection.Redirect;
-//import wraith.waystones.util.Config;
-//import wraith.waystones.util.Utils;
-//
-//import java.util.List;
-//import java.util.Random;
-//import java.util.function.Function;
-//
-//@Mixin(StructurePoolBasedGenerator.StructurePoolGenerator.class)
-//public class StructurePoolBasedGeneratorMixin {
-//
-//    @Shadow
-//    @Final
-//    private List<? super PoolStructurePiece> children;
-//    TODO: Fix this
-//    @Redirect(method = "generatePiece", at = @At(value = "INVOKE", target = "Lnet/minecraft/structure/pool/StructurePool;getElementIndicesInRandomOrder(Ljava/util/Random;)Ljava/util/List;", ordinal = 0))
-//    private List<StructurePoolElement> test(StructurePool originalPool, Random random) {
-//        var config = Config.getInstance();
-//        var poolAccess = (StructurePoolAccessor) originalPool;
-//        Function<String, Boolean> isWaystonePool = s -> s.contains("waystone") && s.contains("village_waystone");
-//        var ret = originalPool.getElementIndicesInRandomOrder(random);
-//        if (config.generateInVillages() && poolAccess.getElements().stream().anyMatch(element -> isWaystonePool.apply(element.toString()))) {
-//            var addedWaystones = children.stream().filter(element -> isWaystonePool.apply(element.toString())).count();
-//            if (addedWaystones < config.getMaxPerVillage() || (addedWaystones < config.getMaxPerVillage() && Utils.getRandomIntInRange(0, poolAccess.getElements().size()) < config.getMaxPerVillage())) {
-//                ret = ret.stream().filter(element -> isWaystonePool.apply(element.toString())).toList();
-//            }
-//        } else {
-//            ret =ret.stream().filter(element -> !isWaystonePool.apply(element.toString())).toList();
-//        }
-//        return ret;
-//    }
-//
-//}
-//
+package wraith.waystones.mixin;
+
+import net.minecraft.structure.PoolStructurePiece;
+import net.minecraft.structure.Structure;
+import net.minecraft.structure.pool.SinglePoolElement;
+import net.minecraft.structure.pool.StructurePool;
+import net.minecraft.structure.pool.StructurePoolBasedGenerator;
+import net.minecraft.structure.pool.StructurePoolElement;
+import net.minecraft.util.BlockRotation;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockBox;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.HeightLimitView;
+import org.apache.commons.lang3.mutable.MutableObject;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import wraith.waystones.util.WaystonesWorldgen;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+@Mixin(StructurePoolBasedGenerator.StructurePoolGenerator.class)
+public class StructurePoolBasedGeneratorMixin {
+
+    @Shadow
+    @Final
+    private List<? super PoolStructurePiece> children;
+
+    @Inject(method = "generatePiece(Lnet/minecraft/structure/PoolStructurePiece;Lorg/apache/commons/lang3/mutable/MutableObject;IZLnet/minecraft/world/HeightLimitView;)V",
+        at = @At(value = "INVOKE", target = "Ljava/util/List;addAll(Ljava/util/Collection;)Z", ordinal = 0, shift = At.Shift.AFTER, remap = false),
+        locals = LocalCapture.CAPTURE_FAILSOFT)
+    private void fabricwaystones_limitWaystonePieceSpawning(PoolStructurePiece piece,
+                                                            MutableObject<VoxelShape> pieceShape,
+                                                            int minY,
+                                                            boolean modifyBoundingBox,
+                                                            HeightLimitView world,
+                                                            CallbackInfo ci,
+                                                            StructurePoolElement structurePoolElement,
+                                                            BlockPos blockPos,
+                                                            BlockRotation blockRotation,
+                                                            StructurePool.Projection projection,
+                                                            boolean bl,
+                                                            MutableObject<VoxelShape> mutableObject,
+                                                            BlockBox blockBox,
+                                                            int i,
+                                                            Iterator<Structure.StructureBlockInfo> var14,
+                                                            Structure.StructureBlockInfo structureBlockInfo,
+                                                            Direction direction,
+                                                            BlockPos blockPos2,
+                                                            BlockPos blockPos3,
+                                                            int j,
+                                                            int k,
+                                                            Identifier identifier,
+                                                            Optional<StructurePool> optional,
+                                                            Identifier identifier2,
+                                                            Optional<StructurePool> optional2,
+                                                            MutableObject<Object> mutableObject2,
+                                                            boolean bl2,
+                                                            List<StructurePoolElement> list)
+    {
+        if(optional.isPresent() && WaystonesWorldgen.VANILLA_VILLAGES.containsKey(optional.get().getId())) {
+            if(children.stream().anyMatch(element -> {
+                if(element instanceof PoolStructurePiece poolStructurePiece &&
+                        poolStructurePiece.getPoolElement() instanceof SinglePoolElement singlePoolElement) {
+                    return ((SinglePoolElementAccessor)singlePoolElement).getLocation().left().orElse(new Identifier("empty")).getNamespace().equals("waystones");
+                }
+                return false;
+            })) {
+                list.removeIf(element -> {
+                    if(element instanceof SinglePoolElement singlePoolElement) {
+                        return ((SinglePoolElementAccessor)singlePoolElement).getLocation().left().orElse(new Identifier("empty")).getNamespace().equals("waystones");
+                    }
+                    return false;
+                });
+            }
+        }
+    }
+}

--- a/src/main/resources/waystones.mixins.json
+++ b/src/main/resources/waystones.mixins.json
@@ -11,6 +11,7 @@
     "SinglePoolElementAccessor",
     "StructurePiecesListMixin",
     "StructurePoolAccessor",
+    "StructurePoolBasedGeneratorMixin",
     "StructureStartAccessor",
     "TagGroupLoaderMixin"
   ],


### PR DESCRIPTION
could change mixin to not be an inject with large amounts of local captures but this does indeed work. Though it is searching for any piece with waystone namespace. Can change that to only check for the piece names in the value portion of VANILLA_VILLAGES field. so you or others can add other waystone namespaced pieces to villages.
![image](https://user-images.githubusercontent.com/40846040/167302581-8b81c8b1-c2f1-44d5-8597-f70e244fcf2f.png)


Also fixes the empty processor logspam error as it was using the wrong empty processor for the injected pieces