### PR TITLE
Journeymap integration fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ fabric_version=0.51.1+1.18.2
 # Journeymap & api
 journeymap_api_version=1.18.2-1.8-fabric-SNAPSHOT
 jm_project_id=32274
-jm_file_id=3779278
+jm_file_id=3796377

--- a/src/main/java/wraith/waystones/integration/event/WaystoneEvents.java
+++ b/src/main/java/wraith/waystones/integration/event/WaystoneEvents.java
@@ -17,17 +17,15 @@ public class WaystoneEvents
         }
     });
 
-    public static final Event<UpdateWaystone> DISCOVER_WAYSTONE_EVENT = EventFactory.createArrayBacked(UpdateWaystone.class, callbacks -> event -> {
-        for (UpdateWaystone callback : callbacks)
-        {
-            callback.onUpdate(event);
+    public static final Event<UpdateWaystone> DISCOVER_WAYSTONE_EVENT = EventFactory.createArrayBacked(UpdateWaystone.class, callbacks -> hash -> {
+        for (UpdateWaystone callback : callbacks) {
+            callback.onUpdate(hash);
         }
     });
 
-    public static final Event<UpdateWaystone> RENAME_WAYSTONE_EVENT = EventFactory.createArrayBacked(UpdateWaystone.class, callbacks -> event -> {
-        for (UpdateWaystone callback : callbacks)
-        {
-            callback.onUpdate(event);
+    public static final Event<UpdateWaystone> RENAME_WAYSTONE_EVENT = EventFactory.createArrayBacked(UpdateWaystone.class, callbacks -> hash -> {
+        for (UpdateWaystone callback : callbacks) {
+            callback.onUpdate(hash);
         }
     });
 


### PR DESCRIPTION
This updates to journeymap 5.8.4. 
Fixes renaming waystone and colors, so waypoints do not change colors when renaming the waystone.
Added a failsafe in-case the on-disk waypoint does not get loaded into memory properly for removal.