### PR TITLE
Avoid AWT (more server friendly).

### DIFF
--- a/src/main/java/wraith/waystones/util/Utils.java
+++ b/src/main/java/wraith/waystones/util/Utils.java
@@ -24,7 +24,6 @@ import wraith.waystones.screen.AbyssScreenHandler;
 import wraith.waystones.screen.PocketWormholeScreenHandler;
 import wraith.waystones.screen.WaystoneBlockScreenHandler;
 
-import java.awt.*;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -304,10 +303,7 @@ public final class Utils {
     }
     public static int getRandomColor() {
         Random rand = new Random();
-        float r = rand.nextFloat();
-        float g = rand.nextFloat();
-        float b = rand.nextFloat();
-        return new Color(r, g, b).getRGB();
+        return rand.nextInt(256) << 16 + rand.nextInt(256) << 8 + rand.nextInt(256);
     }
 
 }


### PR DESCRIPTION
This is basically a feature request.  Using AWT in server code requires the full JRE, which in turn requires a lot of GUI components which are otherwise unnecessary to run Minecraft.  Fabric Waystones recently (in https://github.com/LordDeatHunter/FabricWaystones/commit/d972d16d731850faa52ae44f9bab2e45937c16c1 I think) started requiring AWT.  However, at this time all it is used for is to select a random color.  This PR should duplicate the behavior but without AWT (however, I haven't got a Forge testing setup so I am not sure how to test this).

Here's an example of why I care ... the following are the packages I have to add on a Debian-based server to use AWT:

```
adwaita-icon-theme
fontconfig
gtk-update-icon-cache
hicolor-icon-theme
libatk1.0-0
libatk1.0-data
libcairo2
libdatrie1
libdeflate0
libdrm-amdgpu1
libdrm-common
libdrm-intel1
libdrm-nouveau2
libdrm-radeon1
libdrm2
libfribidi0
libgdk-pixbuf-2.0-0
libgdk-pixbuf2.0-common
libgif7
libgl1
libgl1-mesa-dri
libglapi-mesa
libglvnd0
libglx-mesa0
libglx0
libgtk2.0-0
libgtk2.0-common
libjbig0
libllvm11
libpango-1.0-0
libpangocairo-1.0-0
libpangoft2-1.0-0
libpciaccess0
libpixman-1-0
libthai-data
libthai0
libtiff5
libvulkan1
libwebp6
libx11-xcb1
libxcb-dri2-0
libxcb-dri3-0
libxcb-glx0
libxcb-present0
libxcb-render0
libxcb-shm0
libxcb-sync1
libxcb-xfixes0
libxcomposite1
libxcursor1
libxdamage1
libxfixes3
libxi6
libxinerama1
libxrandr2
libxrender1
libxshmfence1
libxtst6
libxxf86vm1
libz3-4
openjdk-17-jre
shared-mime-info
x11-common
```