### PR TITLE
Inject waystones into Repurposed Structures zombie variant villages

### DIFF
--- a/src/main/resources/data/repurposed_structures/pool_additions/villages/badlands/zombie/houses.json
+++ b/src/main/resources/data/repurposed_structures/pool_additions/villages/badlands/zombie/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/badlands/zombie/houses",
+  "fallback": "repurposed_structures:villages/badlands/zombie/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "fwaystones:red_desert_village_waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "fwaystones:config"
+    }
+  ]
+}

--- a/src/main/resources/data/repurposed_structures/pool_additions/villages/bamboo/zombie/houses.json
+++ b/src/main/resources/data/repurposed_structures/pool_additions/villages/bamboo/zombie/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/bamboo/zombie/houses",
+  "fallback": "repurposed_structures:villages/bamboo/zombie/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "fwaystones:mossy_stone_brick_village_waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "fwaystones:config"
+    }
+  ]
+}

--- a/src/main/resources/data/repurposed_structures/pool_additions/villages/birch/zombie/houses.json
+++ b/src/main/resources/data/repurposed_structures/pool_additions/villages/birch/zombie/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/birch/zombie/houses",
+  "fallback": "repurposed_structures:villages/birch/zombie/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "fwaystones:village_waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "fwaystones:config"
+    }
+  ]
+}

--- a/src/main/resources/data/repurposed_structures/pool_additions/villages/cherry/zombie/houses.json
+++ b/src/main/resources/data/repurposed_structures/pool_additions/villages/cherry/zombie/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/cherry/zombie/houses",
+  "fallback": "repurposed_structures:villages/cherry/zombie/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "fwaystones:stone_brick_village_waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "fwaystones:config"
+    }
+  ]
+}

--- a/src/main/resources/data/repurposed_structures/pool_additions/villages/crimson/zombie/houses.json
+++ b/src/main/resources/data/repurposed_structures/pool_additions/villages/crimson/zombie/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/crimson/zombie/houses",
+  "fallback": "repurposed_structures:villages/crimson/zombie/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "fwaystones:red_nether_brick_village_waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "fwaystones:config"
+    }
+  ]
+}

--- a/src/main/resources/data/repurposed_structures/pool_additions/villages/dark_forest/zombie/houses.json
+++ b/src/main/resources/data/repurposed_structures/pool_additions/villages/dark_forest/zombie/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/dark_forest/zombie/houses",
+  "fallback": "repurposed_structures:villages/dark_forest/zombie/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "fwaystones:village_waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "fwaystones:config"
+    }
+  ]
+}

--- a/src/main/resources/data/repurposed_structures/pool_additions/villages/giant_taiga/zombie/houses.json
+++ b/src/main/resources/data/repurposed_structures/pool_additions/villages/giant_taiga/zombie/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/giant_taiga/zombie/houses",
+  "fallback": "repurposed_structures:villages/giant_taiga/zombie/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "fwaystones:village_waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "fwaystones:config"
+    }
+  ]
+}

--- a/src/main/resources/data/repurposed_structures/pool_additions/villages/jungle/zombie/houses.json
+++ b/src/main/resources/data/repurposed_structures/pool_additions/villages/jungle/zombie/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/jungle/zombie/houses",
+  "fallback": "repurposed_structures:villages/jungle/zombie/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "fwaystones:mossy_stone_brick_village_waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "fwaystones:config"
+    }
+  ]
+}

--- a/src/main/resources/data/repurposed_structures/pool_additions/villages/mountains/zombie/houses.json
+++ b/src/main/resources/data/repurposed_structures/pool_additions/villages/mountains/zombie/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/jungle/zombie/houses",
+  "fallback": "repurposed_structures:villages/jungle/zombie/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "fwaystones:mossy_stone_brick_village_waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "fwaystones:config"
+    }
+  ]
+}

--- a/src/main/resources/data/repurposed_structures/pool_additions/villages/oak/zombie/houses.json
+++ b/src/main/resources/data/repurposed_structures/pool_additions/villages/oak/zombie/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/oak/zombie/houses",
+  "fallback": "repurposed_structures:villages/oak/zombie/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "fwaystones:village_waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "fwaystones:config"
+    }
+  ]
+}

--- a/src/main/resources/data/repurposed_structures/pool_additions/villages/swamp/zombie/houses.json
+++ b/src/main/resources/data/repurposed_structures/pool_additions/villages/swamp/zombie/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/swamp/zombie/houses",
+  "fallback": "repurposed_structures:villages/swamp/zombie/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "fwaystones:village_waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "fwaystones:config"
+    }
+  ]
+}

--- a/src/main/resources/data/repurposed_structures/pool_additions/villages/warped/zombie/houses.json
+++ b/src/main/resources/data/repurposed_structures/pool_additions/villages/warped/zombie/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/warped/zombie/houses",
+  "fallback": "repurposed_structures:villages/warped/zombie/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "fwaystones:nether_brick_village_waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "fwaystones:config"
+    }
+  ]
+}


### PR DESCRIPTION
Will resolve https://github.com/LordDeatHunter/FabricWaystones/issues/227

Background, a user had a terrible giant lagspike with a Waystones mod on. Upon long investigation, the issue turned out that because the JSON files I added to Waystones mods have the Waystone piece marked as required and is injected into the non-zombie house piece, Repurposed Structures attempting to spawn a zombie variant village will keep retrying up to 100 times to find a zombie village layout that has the Waystone piece that it'll never have
https://github.com/TelepathicGrunt/RepurposedStructures/issues/306

This issue affects 1.19.2 and 1.20.1. I already released a fix on my end for both versions by now rerolling the start piece if redoing the layout and lowered the retrying to 40 attempts. The side-effect of this fix means zombie villages won't spawn with Waystones mods on. This PR adds the Waystones pieces to the zombie village's house pools so now zombie villages can spawn with Repurposed Structures on again and can have a Waystone piece. (Note, Mushroom and Ocean do not have separate zombie variants. If backporting to 1.19.2, do not include Cherry and Bamboo as they are 1.20.1 exclusives)